### PR TITLE
Introduction of github matrix in django pipeline

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   outdated:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -20,7 +20,7 @@ jobs:
       run: pip list --outdated --not-required --user | grep . && echo "there are outdated packages" && exit 1 || echo "all packages up to date"
 
   black:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -34,7 +34,7 @@ jobs:
       run: black --check .
 
   isort:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -48,7 +48,7 @@ jobs:
       run: isort **/*.py -c -vb
 
   security:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -72,47 +72,32 @@ jobs:
         name: Bandit Security Report
         path: report.json
 
-  django_check:
-    runs-on: ubuntu-18.04
+  django_matrix:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
       with:
-        python-version: 3.8.2
-
-    - name: pip install
-      run: pip install -r requirements.txt 
-
-    - name: check
-      run: python manage.py check
-
-  django_test:
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.8.2
-
-    - name: pip install
-      run: pip install -r requirements.txt 
-
-    - name: test
-      run: python manage.py test
-      
-  django_templates:
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.8.2
-
-    - name: pip install
-      run: pip install -r requirements.txt 
-
-    - name: validate_templates
-      run: python manage.py validate_templates
+        python-version: ${{ matrix.python-version }}
+    - name: Install Dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Django test runner
+      run: |
+        python manage.py test
+    - name: Django souce code check
+      run: |
+        python manage.py check
+    - name: Django Template validation
+      run: |
+        python manage.py validate_templates
 
   docker:
     runs-on: ubuntu-18.04
@@ -120,4 +105,4 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: docker build
-      run: docker build -t python-demo .
+      run: docker build -t django-pipeline-demo .


### PR DESCRIPTION
Allow the check of Django against python 3.6, 3.7., and 3.8. 

Please note that you can do the same with the Django Version, and compile against different Django Versions.

An example application of this feature could be a test of the current stable Django version versus the newest Develop version. It will show you if your source code might be impacted by future changes in the newest development branch of Django.