### PR TITLE
Create isort.cfg

### DIFF
--- a/isort.cfg
+++ b/isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88


### PR DESCRIPTION
isort does not provide a black confirm sort of imports without a tweak.